### PR TITLE
Add a License to the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name" : "ministryofjustice/date-utils",
     "description" : "Utility classes for working day and bank holiday calculations",
     "type" : "library",
+    "license": "MIT",
     "require" : {
         "php" : ">=5.4"
     },


### PR DESCRIPTION
Since it's not clear what license the package is under it's hard to know if it's compatible with what is being used on a given project.

I suggest adding the MIT License as it is the most permissive license. If code sharing is important to you then `LGPL-3.0` would be another option.

Making this change would also solve the warning currently displayed on packagist:
https://packagist.org/packages/ministryofjustice/date-utils